### PR TITLE
 TwitterへのシェアURLの形式を変更します

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -36,8 +36,8 @@ export const App: FC = () => {
                     moji.status === 'ok'
                       ? 'green'
                       : moji.status === 'ng'
-                      ? 'red'
-                      : 'gray',
+                        ? 'red'
+                        : 'gray',
                 }}
               >
                 {moji.char}
@@ -77,7 +77,7 @@ const TweetButton: FC<{ yaruzoInput: string; disabled: boolean }> = ({
   return (
     <a
       className={styles.tweetButton}
-      href={`http://twitter.com/share?url=https://kazuhi-ra.github.io/human-power&text=${yaruzoInput}`}
+      href={`https://twitter.com/intent/tweet?url=https://kazuhi-ra.github.io/human-power&text=${yaruzoInput}`}
       target="_blank"
       rel="noreferrer"
     >


### PR DESCRIPTION
##解決すること
Androidで正しく Twitterへ遷移し、ツイートできるようにします

## 変更点
`https://twitter.com/share?` の形式がAndroidアプリでエラーになるため、
`https://twitter.com/intent/tweet?`に変更します。

ref:
https://twitter.com/nabettu/status/1605475625602465796?s=20&t=fvEF0hLxr1OOTAnk9IFQpw